### PR TITLE
BMO Regex Update for Statements September 2023 Onwards

### DIFF
--- a/teller/pdf_processor.py
+++ b/teller/pdf_processor.py
@@ -17,7 +17,7 @@ regexes = {
             r"(?P<description>.+)\s"
             r"(?P<amount>-?[\d,]+\.\d{2})(?P<cr>(\-|\s*CR))?"),
         'startyear': r'Statement period\s\w+\.?\s{1}\d+\,\s{1}(?P<year>[0-9]{4})',
-        'openbal': r'Previous balance.*(?P<balance>-?\$[\d,]+\.\d{2})(?P<cr>(\-|\s?CR))?',
+        'openbal': r'Previous total balance.*(?P<balance>-?\$[\d,]+\.\d{2})(?P<cr>(\-|\s?CR))?',
         'closingbal': r'(?:Total) balance\s.*(?P<balance>-?\$[\d,]+\.\d{2})(?P<cr>(\-|\s?CR))?'
     },
     'RBC': {


### PR DESCRIPTION
"Previous Balance, MMM. DD, YYYY" changed to "Previous total balance, MMM. DD, YYYY"